### PR TITLE
fix: download 256x256 image by coords

### DIFF
--- a/backend/api/app/sentinel_hub/service.py
+++ b/backend/api/app/sentinel_hub/service.py
@@ -70,10 +70,10 @@ class SentinelHubService:
     def search_and_save_images(self, search_date, coords) -> Dict[str, str]:
         size_degrees = (256 * 10) / 111320
         bbox = BBox([
-            coords.lon - size_degrees / 2,
-            coords.lat - size_degrees / 2,
-            coords.lon + size_degrees / 2,
-            coords.lat + size_degrees / 2
+            coords[0] - size_degrees / 2,
+            coords[1] - size_degrees / 2,
+            coords[0] + size_degrees / 2,
+            coords[1] + size_degrees / 2
         ], crs=CRS.WGS84)
 
         requests = {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Adjust the image download function to ensure that images are consistently downloaded in a 256x256 pixel format by modifying the bounding box calculation and fixing the image size parameter.

### Why are these changes being made?

The changes ensure consistency in the image dimensions when downloading satellite imagery, which addresses an inconsistency issue related to varying image resolutions. The updated bounding box calculation and explicit size specification to (256, 256) pixels correct any previous misalignment and ensure compatibility with expected image processing workflows.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->